### PR TITLE
Hotfix of problem with class name duplication

### DIFF
--- a/src/main/java/com/cadrlife/jhaml/internal/Helper.java
+++ b/src/main/java/com/cadrlife/jhaml/internal/Helper.java
@@ -349,7 +349,10 @@ public class Helper {
 			attrMap.remove("id");
 		}
 		if (attrMap.containsKey("class")) {
-			classes.add(0, attrMap.get("class").value);
+			String className = attrMap.get("class").value;
+			if (!classes.contains(className)) {
+				classes.add(0, className);
+			}
 			attrMap.remove("class");
 		}
 		getErrorChecker().setCurrentLineNumber(line.lineNumber);

--- a/src/test/java/com/cadrlife/jhaml/EmbeddedJavaCodeTest.java
+++ b/src/test/java/com/cadrlife/jhaml/EmbeddedJavaCodeTest.java
@@ -73,4 +73,10 @@ public class EmbeddedJavaCodeTest {
     	String html = "<% aList.each { %>\n  <p />\n<% } %>";
     	assertEquals(html, jhaml.parse("- aList.each\n  %p/"));
     }
+
+	@Test
+	public void forLoopIfInnerElementWithClass() {
+		String html = "<% for (int i=0; i<2; i++) { %>\n  <p class='test' />\n<% } %>";
+		assertEquals(html, jhaml.parse("- for (int i=0; i<2; i++)\n  %p.test/"));
+	}
 }

--- a/src/test/java/com/cadrlife/jhaml/JHamlTest.java
+++ b/src/test/java/com/cadrlife/jhaml/JHamlTest.java
@@ -198,8 +198,8 @@ public class JHamlTest {
 
 	@Test
 	public void elementsWithMultipleClasses() {
-		String html = "<p class='a b c'></p>";
-		assertEquals(html, jhaml.parse("%p.b.c{:class=>'a'}"));
+		assertEquals("<p class='a b'></p>", jhaml.parse("%p.a.b"));
+		assertEquals("<p class='a b c'></p>", jhaml.parse("%p.b.c{:class=>'a'}"));
 	}
 
 	@Test


### PR DESCRIPTION
``` groovy
- for text in ["text1", "text2"]
  .test= text
```

Expected:

``` html
 <div class='test'>text1</div>

 <div class='test'>text2</div>
```

Actual:

``` html
 <div class='test test'>text1</div>

 <div class='test test'>text2</div>
```
