### PR TITLE
Seem to fix jsp nested expression bug

### DIFF
--- a/src/main/java/com/cadrlife/jhaml/internal/Helper.java
+++ b/src/main/java/com/cadrlife/jhaml/internal/Helper.java
@@ -143,6 +143,11 @@ public class Helper {
 
 	public String jspExpression(String lineText, String code) {
 		getErrorChecker().checkJavaCodeIsNotEmpty(lineText, "=", code);
+		final String[] parts = code.split("\\n", 2);
+		if (parts.length>2) // should never happen according to contract of String#split()
+			throw new RuntimeException("Have bug!");
+		if (parts.length>1)
+			return "<%= " + parts[0] + " %>\n" + parts[1];
 		return "<%= " + code + " %>";
 	}
 
@@ -218,16 +223,16 @@ public class Helper {
 			return DOCTYPE_HTML;
 		}
 		// TODO: This regex is from the Ruby implementation, and could be updated for Java.
-//		Pattern pattern = Pattern.compile("(\\d(?:\\.\\d)?)?[\\s]*([a-z]*)",
-//				Pattern.CASE_INSENSITIVE);
+		//		Pattern pattern = Pattern.compile("(\\d(?:\\.\\d)?)?[\\s]*([a-z]*)",
+		//				Pattern.CASE_INSENSITIVE);
 		String version = tokens.length > 0 ? tokens[0] : "";
 		String type = tokens.length > 1 ? tokens[1] : "";
 		if (CharMatcher.JAVA_LETTER.matchesAllOf(version)) {
 			type = version;
 			version = "";
 		}
-//		System.err.println("<" + version + ">");
-//		System.err.println("<" + type + ">");
+		//		System.err.println("<" + version + ">");
+		//		System.err.println("<" + type + ">");
 		// version, type = text.scan(DOCTYPE_REGEX )[0]
 		if (config.isXhtml()) {
 			if ("1.1".equals(version)) {
@@ -282,7 +287,7 @@ public class Helper {
 		String remainingLines = string.substring(string.indexOf("\n"));
 		return "<% if " + condition + " { %>" + remainingLines + "\n<% } %>";
 	}
-	
+
 	private String elseBlock(String string) {
 		String firstLine = string.substring(0, string.indexOf("\n"));
 		if (firstLine.contains("if") && firstLine.replaceAll("\\s", "").startsWith("elseif")) {
@@ -312,7 +317,7 @@ public class Helper {
 		String remainingLines = string.substring(string.indexOf("\n"));
 		return "<% for " + condition + " { %>" + remainingLines + "\n<% } %>";
 	}
-	
+
 	private String groovyEachLoop(String string) {
 		String listName = string.substring(0, string.indexOf(".each")).trim();
 		String remainingLines = string.substring(string.indexOf("\n"));

--- a/src/main/java/com/cadrlife/jhaml/internal/Helper.java
+++ b/src/main/java/com/cadrlife/jhaml/internal/Helper.java
@@ -147,7 +147,7 @@ public class Helper {
 		if (parts.length>2) // should never happen according to contract of String#split()
 			throw new RuntimeException("Have bug!");
 		if (parts.length>1)
-			return "<%= " + parts[0] + " %>\n" + parts[1];
+			return "<%= " + parts[0] + " %>\n" + parts[1]+"\n";
 		return "<%= " + code + " %>";
 	}
 

--- a/src/test/java/com/cadrlife/jhaml/EmbeddedJavaCodeTest.java
+++ b/src/test/java/com/cadrlife/jhaml/EmbeddedJavaCodeTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 public class EmbeddedJavaCodeTest {
 	private JHaml jhaml = new JHaml();
 	
-	@Test
+    @Test
     public void jspScriptlet() {
  	   assertEquals("<% foo(bar); %>", jhaml.parse("- foo(bar);"));
  	   assertEquals("<p>\n  <% foo(bar); %>\n</p>", jhaml.parse("%p\n - foo(bar);"));
@@ -19,7 +19,14 @@ public class EmbeddedJavaCodeTest {
  	   assertEquals("<%= foo(bar); %>", jhaml.parse("= foo(bar);"));
  	   assertEquals("<p><%= foo(bar); %></p>", jhaml.parse("%p= foo(bar);"));
     }
-    
+
+    @Test
+    public void nestedExpression() {
+	    String haml = "%li=item\n  #nested_div";
+	    String html = "<li><%= item %>\n  <div id='nested_div'></div>\n</li>";
+	    assertEquals(html,jhaml.parse(haml));
+    }
+
     @Test
     public void ifStatement() {
     	String html = "<% if (1+1==2) { %>\n  <p />\n<% } %>";


### PR DESCRIPTION
Fixed bug where nested expression like
%li=foobar
  #nested_expression
was rendering as
`<li><%= foobar
  <div id='nested_expression'>
  </div> %>`
