### PR TITLE
JHamlBatchConverter improvement

### DIFF
--- a/src/main/java/com/cadrlife/jhaml/JHaml.java
+++ b/src/main/java/com/cadrlife/jhaml/JHaml.java
@@ -18,18 +18,17 @@ public class JHaml {
 	private Helper helper;
 	private int indentationSize = -1;
 	private boolean isIndentWithTabs = false;
-	private final JHamlConfig config;
-	
+
 	public JHaml() {
 		this(new JHamlConfig());
 	}
+
 	public JHaml(JHamlConfig config) {
-		this.config = config;
 		helper = new Helper(config);
+		helper.getErrorChecker().validateConfig(config);
 	}
 	
 	public String parse(String input) {
-		helper.getErrorChecker().validateConfig(this.config);
 		indentationSize = -1;
 		isIndentWithTabs = false;
 		if (StringUtils.isBlank(input.trim())) {

--- a/src/main/java/com/cadrlife/jhaml/JHamlBatchConverter.java
+++ b/src/main/java/com/cadrlife/jhaml/JHamlBatchConverter.java
@@ -17,6 +17,7 @@ public class JHamlBatchConverter extends DirectoryWalker {
 	private String targetExtenstion = "jsp";
 	private boolean outputModificationWarning = true;
 	private Charset charset = Charset.defaultCharset();
+	private JHamlConfig config;
 	
 	public List<File> convertAllInPath(File startDirectory) throws IOException {
 		List<File> results = new ArrayList<File>();
@@ -28,8 +29,8 @@ public class JHamlBatchConverter extends DirectoryWalker {
 	protected void handleFile(File file, Collection<File> results) throws IOException {
 		if (file.getName().endsWith("." + hamlExtension)) {
 			String warning = warning(file.getName());
-			String gsp = new JHaml()
-					.parse(Files.toString(file, getCharset()));
+			JHaml haml = (config == null) ? new JHaml() : new JHaml(config);
+			String gsp = haml.parse(Files.toString(file, getCharset()));
 			String gspFileName = file.getAbsolutePath().replaceAll(
 					"\\." + Pattern.quote(hamlExtension) + "$", "." + targetExtenstion);
 			Files.write(warning + gsp, new File(gspFileName), getCharset());
@@ -87,4 +88,7 @@ public class JHamlBatchConverter extends DirectoryWalker {
 		return outputModificationWarning;
 	}
 
+	public void setConfig(JHamlConfig config) {
+		this.config = config;
+	}
 }


### PR DESCRIPTION
Add JHamlBatchConverter::setConfig() method for nondefault config using.
This fix needed for haml4grails plugin, for example use single quotes instead of double for html attributes values.
